### PR TITLE
Create p4

### DIFF
--- a/app/controllers/organizations_controller.rb
+++ b/app/controllers/organizations_controller.rb
@@ -27,6 +27,7 @@ class OrganizationsController < ApplicationController
     authorize Organization
 
     @organization = Organization.new
+
     respond_with(@organization)
   end
 
@@ -38,7 +39,15 @@ class OrganizationsController < ApplicationController
     authorize Organization
 
     @organization = Organization.new(organization_params)
-    flash[:notice] = 'Organization was successfully created.' if @organization.save
+
+    if @organization.save
+      flash[:notice] = 'Organization was successfully created.'
+      flash[:notice] = "User default_"+"#{@organization.name}".gsub!(/\W/, "")+"_#{@organization.country}@example.com created."
+
+      @newautouser = User.create(:name => "Default_#{@organization.name}_#{@organization.country}".gsub!(/\W/, ""), email: "default_#{@organization.name}_#{@organization.country}".gsub!(/\W/, "")+"@example.com", :organization => @organization, :clearance => :Public, :role => :p1, :password => 'change', :password_confirmation => 'change')
+      @newautouser.confirm!
+    
+    end
     respond_with(@organization)
   end
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -23,9 +23,9 @@ class UsersController < ApplicationController
   end
 
   def destroy
-    user = User.find(params[:id])
-    authorize user
-    user.destroy
+    @user = User.find(params[:id])
+    authorize @user
+    @user.destroy
     redirect_to users_path, :notice => "User deleted."
   end
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -3,8 +3,8 @@ class UsersController < ApplicationController
   after_action :verify_authorized
 
   def index
-    @users = User.all
-    authorize User
+    authorize current_user
+    @users = policy_scope(User)
   end
 
   def show

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -1,6 +1,6 @@
 class Comment < ActiveRecord::Base
-  enum sensitivity: { publico: 0, privado: 1, secreto: 2}
-  enum level: { local: 0, national: 1, international: 2}
+  enum sensitivity: { Public: 0, Private: 1, Secret: 2}
+  enum level: { Local: 0, National: 1, International: 2}
 
   belongs_to :event
   belongs_to :user

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -1,6 +1,6 @@
 class Event < ActiveRecord::Base
-  enum sensitivity: { publico: 0, privado: 1, secreto: 2}
-  enum level: { local: 0, national: 1, international: 2}
+  enum sensitivity: { Public: 0, Private: 1, Secret: 2}
+  enum level: { Local: 0, National: 1, International: 2}
 
   belongs_to :user
   belongs_to :situation

--- a/app/models/situation.rb
+++ b/app/models/situation.rb
@@ -1,6 +1,6 @@
 class Situation < ActiveRecord::Base
-  enum sensitivity: { publico: 0, privado: 1, secreto: 2}
-  enum level: { local: 0, national: 1, international: 2}
+  enum sensitivity: { Public: 0, Private: 1, Secret: 2}
+  enum level: { Local: 0, National: 1, International: 2}
 
   has_many :participations
   has_many :organizations, :through => :participations

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -17,5 +17,5 @@ class User < ActiveRecord::Base
   has_many :events
   has_many :situations
   belongs_to :organization
-  validates_presence_of :organization
+  validates_presence_of :organization, :unless => Proc.new { |u| u.admin? }
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,12 +1,12 @@
 class User < ActiveRecord::Base
   enum role: { p1: 0, p2: 1, p3: 2, admin: 4 }
-  enum clearance: { publico: 0, privado: 1, secreto: 2}
+  enum clearance: { Public: 0, Private: 1, Secret: 2}
 
   after_initialize :set_default_role_and_sensitivity
 
   def set_default_role_and_sensitivity
     self.role ||= :p1
-    self.clearance ||= :publico
+    self.clearance ||= :Public
   end
 
   # Include default devise modules. Others available are:

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,11 +1,11 @@
 class User < ActiveRecord::Base
-  enum role: { p1: 0, p2: 1, p3: 2, admin: 4 }
+  enum role: { p0: 0, p1: 1, p2: 2, p3: 3, p4: 4, admin: 5 }
   enum clearance: { Public: 0, Private: 1, Secret: 2}
 
   after_initialize :set_default_role_and_sensitivity
 
   def set_default_role_and_sensitivity
-    self.role ||= :p1
+    self.role ||= :p0
     self.clearance ||= :Public
   end
 
@@ -17,5 +17,5 @@ class User < ActiveRecord::Base
   has_many :events
   has_many :situations
   belongs_to :organization
-  validates_presence_of :organization, :unless => Proc.new { |u| u.admin? }
+  validates_presence_of :organization
 end

--- a/app/policies/comment_policy.rb
+++ b/app/policies/comment_policy.rb
@@ -26,7 +26,7 @@ class CommentPolicy < ApplicationPolicy
   end
 
   def create?
-    user.admin? || user.p3? || user.p2?
+    user.admin? || user.p4? || user.p3? || user.p2?
   end
 
   def update?

--- a/app/policies/comment_policy.rb
+++ b/app/policies/comment_policy.rb
@@ -15,8 +15,8 @@ class CommentPolicy < ApplicationPolicy
               AND (level = :national_level))  OR 
               (level = :international_level) )",
               {organization_id: user.organization.id, user_clearance: user_clearance, 
-                user_country: user.organization.country, local_level: levels[:local],
-                national_level: levels[:national], international_level: levels[:international]})
+                user_country: user.organization.country, local_level: levels[:Local],
+                national_level: levels[:National], international_level: levels[:International]})
       end
     end
   end

--- a/app/policies/event_policy.rb
+++ b/app/policies/event_policy.rb
@@ -14,8 +14,8 @@ class EventPolicy < ApplicationPolicy
               AND (level = :national_level))  OR 
               (level = :international_level) )",
               {organization_id: user.organization.id, user_clearance: user_clearance, 
-                user_country: user.organization.country, local_level: levels[:local],
-                national_level: levels[:national], international_level: levels[:international]})
+                user_country: user.organization.country, local_level: levels[:Local],
+                national_level: levels[:National], international_level: levels[:International]})
       end
     end
   end

--- a/app/policies/event_policy.rb
+++ b/app/policies/event_policy.rb
@@ -25,7 +25,7 @@ class EventPolicy < ApplicationPolicy
   end
 
   def create?
-    user.admin? || user.p3? || user.p2?
+    user.admin? || user.p4? || user.p3? || user.p2?
   end
 
   def update?

--- a/app/policies/organization_policy.rb
+++ b/app/policies/organization_policy.rb
@@ -18,7 +18,7 @@ class OrganizationPolicy < ApplicationPolicy
   end
 
   def create?
-    user.admin?
+    user.admin? || user.p4?
   end
 
   alias_method :update?, :create?

--- a/app/policies/organization_policy.rb
+++ b/app/policies/organization_policy.rb
@@ -1,7 +1,7 @@
 class OrganizationPolicy < ApplicationPolicy
   class Scope < Scope
     def resolve
-      if defined?(user)=="method" # will now return true or false
+      if defined?(user.id)==nil # will now return true or false
             scope.where("name  <> :orgadmin", {orgadmin: "ADMIN"})        
       else
          if user.admin? || user.p3? || user.p4?
@@ -21,8 +21,11 @@ class OrganizationPolicy < ApplicationPolicy
     user.admin? || user.p4?
   end
 
+  def destroy?
+    user.admin?
+  end
+
   alias_method :update?, :create?
-  alias_method :destroy?, :create?
   alias_method :new?, :create?
   alias_method :edit?, :create?
 end

--- a/app/policies/organization_policy.rb
+++ b/app/policies/organization_policy.rb
@@ -1,16 +1,20 @@
 class OrganizationPolicy < ApplicationPolicy
   class Scope < Scope
     def resolve
-      if user.admin? || user.p3?
-        scope.where("name  <> :orgadmin", {orgadmin: "ADMIN"})
+      if defined?(user)=="method" # will now return true or false
+            scope.where("name  <> :orgadmin", {orgadmin: "ADMIN"})        
       else
-        scope.where(id: user.organization.id)
+         if user.admin? || user.p3? || user.p4?
+            scope.where("name  <> :orgadmin", {orgadmin: "ADMIN"})
+          else
+            scope.where(id: user.organization.id)
+          end 
       end
     end
   end
 
   def show?
-    user.admin? || user.p3? || record == user.organization
+    user.admin? || user.p3? || user.p4? || record == user.organization
   end
 
   def create?

--- a/app/policies/situation_policy.rb
+++ b/app/policies/situation_policy.rb
@@ -13,8 +13,8 @@ class SituationPolicy < ApplicationPolicy
             ((:user_country = (SELECT country FROM organizations WHERE id = owner_organization LIMIT 1)) AND (level = :national_level)) OR
             (level = :international_level))",
           {organization_id: user.organization.id, user_country: user.organization.country,
-            user_clearance: user_clearance, local_level: levels[:local],
-            national_level: levels[:national], international_level: levels[:international]})
+            user_clearance: user_clearance, local_level: levels[:Local],
+            national_level: levels[:National], international_level: levels[:International]})
       end
     end
   end
@@ -26,9 +26,9 @@ class SituationPolicy < ApplicationPolicy
     situation_sensitivity = Situation.sensitivities[record.sensitivity]
 
     record.active? && record.organizations.include?(user.organization) && situation_sensitivity <= user_clearance &&
-      ((record.owner_organization == user.organization && record.local?) ||
-       (record.owner_organization.country == user.organization.country && record.national?) ||
-       (record.international?))
+      ((record.owner_organization == user.organization && record.Local?) ||
+       (record.owner_organization.country == user.organization.country && record.National?) ||
+       (record.International?))
   end
 
   def create?

--- a/app/policies/user_policy.rb
+++ b/app/policies/user_policy.rb
@@ -1,4 +1,4 @@
-class UserPolicy
+class UserPolicy < ApplicationPolicy
   attr_reader :current_user, :model
 
   def initialize(current_user, model)
@@ -6,21 +6,38 @@ class UserPolicy
     @user = model
   end
 
+  class Scope < Scope
+    def resolve
+      if user.admin?
+        scope.all
+      else
+        if user.p4?
+           scope.where("organization_id = :user_organization", {user_organization: user.organization.id})
+        else
+           []
+        end
+      end # if
+    end # def
+  end # class
+
+
+
+
   def index?
-    @current_user.admin?
+    @current_user.admin? || @current_user.p4?
   end
 
   def show?
-    @current_user.admin? or @current_user == @user
+    @current_user.admin? or @current_user.p4? @current_user == @user
   end
 
   def update?
-    @current_user.admin?
+    @current_user.admin? || @current_user.p4?
   end
 
   def destroy?
     return false if @current_user == @user
-    @current_user.admin?
+    @current_user.admin? || @current_user.p4?
   end
 
 end

--- a/app/policies/user_policy.rb
+++ b/app/policies/user_policy.rb
@@ -28,7 +28,7 @@ class UserPolicy < ApplicationPolicy
   end
 
   def show?
-    @current_user.admin? or @current_user.p4? @current_user == @user
+    @current_user.admin? or @current_user.p4? or @current_user == @user
   end
 
   def update?

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -15,7 +15,7 @@
       <%= f.input :password_confirmation, :required => true %>
     </div>
     <div class="form-group">
-      <%= f.input :organization_id, collection: Organization.all, :required => true, error_html: { class: 'has-error'} %>
+      <%= f.input :organization_id, collection: policy_scope(Organization), :label_method => lambda { |org| "#{org.name} - #{org.country}"}, :required => true, error_html: { class: 'has-error'} %>
     </div>
     <%= f.submit 'Sign up', :class => 'button right' %>
   <% end %>

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -17,12 +17,12 @@
       <%= f.password_field :password, class: 'form-control' %>
     </div>
       <%= f.submit 'Sign in', :class => 'button right' %>
-      <% if devise_mapping.rememberable? -%>
+<!--       <% if devise_mapping.rememberable? -%>
         <div class="checkbox" style="width:150px">
           <label>
             <%= f.check_box :remember_me %> Remember me
           </label>
         </div>
-      <% end -%>
+      <% end -%> -->
   <% end %>
 </div>

--- a/app/views/layouts/_header_navigation.html.erb
+++ b/app/views/layouts/_header_navigation.html.erb
@@ -22,11 +22,11 @@
           <li><%= link_to 'Sign in', new_user_session_path %></li>
           <li><%= link_to 'Sign up', new_user_registration_path %></li>
         <% end %>
-        <% if user_signed_in? %>
-          <% if current_user.admin? %>
+        <!-- <% if user_signed_in? %>
+          <% if current_user.admin? || current_user.p4? %>
               <li></i><%= link_to 'Users', users_path %></li>
           <% end %>
-        <% end %>
+        <% end %> -->
 
       </ul>
     </div>

--- a/app/views/situations/index.html.erb
+++ b/app/views/situations/index.html.erb
@@ -15,8 +15,15 @@
             <td><%= situation.sensitivity %></td>
             <td><%= situation.level %></td>
             <td><%= link_to 'Edit', edit_situation_path(situation) %></td>
+            <% if current_user.admin? %>
+                <% if (situation.active) %>
+                   <td><i class="glyphicon glyphicon-folder-open"></i></td>
+                <% else %> 
+                   <td><i class="glyphicon glyphicon-folder-close"></i></td>
+                <% end %>
+            <% end %>   
 <!--             <td><%= link_to 'Destroy', situation, method: :delete, data: { confirm: 'Are you sure?' } %></td>
- -->          </tr>
+ -->      </tr>
         <% end %>
       </tbody>
     </table>

--- a/app/views/situations/show.html.erb
+++ b/app/views/situations/show.html.erb
@@ -2,7 +2,17 @@
   <%= render 'layouts/left_navigation' %>
 
   <div class="col-sm-9">
-     <h3><i class="glyphicon glyphicon-dashboard"></i> <%= @situation.name + ' (' + @situation.sensitivity + ', ' + @situation.level + ')' %> <%= link_to 'Edit', edit_situation_path(@situation), :type => 'button', :class => 'btn btn-primary' %></h3>
+    <h3><i class="glyphicon glyphicon-dashboard"></i> 
+      <%= @situation.name + ' (' + @situation.sensitivity + ', ' + @situation.level + ')' %> 
+      <% if current_user.admin? %>
+        <% if (@situation.active) %>
+           <td><i class="glyphicon glyphicon-folder-open"></i></td>
+        <% else %> 
+           <td><i class="glyphicon glyphicon-folder-close"></i></td>
+        <% end %>
+      <% end %>  
+      <%= link_to 'Edit', edit_situation_path(@situation), :type => 'button', :class => 'btn btn-primary' %>
+    </h3>
      
     <hr>
     <p>
@@ -62,10 +72,10 @@
   <% @events=policy_scope(@situation.events) %>
   <% @events.each do |event| %>
 
-    <% if event.sensitivity == "secreto" %>
+    <% if event.sensitivity == "Secret" %>
         <div class="bs-callout bs-callout-danger" >
     <% else %>
-      <% if event.sensitivity == "privado" %>
+      <% if event.sensitivity == "Private" %>
         <div class="bs-callout bs-callout-warning" >
       <% else %>
         <div class="bs-callout bs-callout-success" >
@@ -75,10 +85,10 @@
        <div class="row">
 
           <!-- Creation time with symbol code for "Local/National/International" -->
-          <% if event.level == "international" %>
+          <% if event.level == "International" %>
               <div class="col-md-3"> <small>(<%= event.created_at %>)  &nbsp  </small> <span class="glyphicon glyphicon-globe"></span>  </div>
           <% else %>
-             <% if event.level == "national" %>
+             <% if event.level == "National" %>
                 <div class="col-md-3">  <small>(<%= event.created_at %>) &nbsp </small> <span class="glyphicon glyphicon-share-alt"></span>  </div>
              <% else %>
                 <div class="col-md-3">  <small>(<%= event.created_at %>) &nbsp </small> <span class="glyphicon glyphicon-chevron-right"></span> </div>
@@ -123,10 +133,10 @@
             <div class="col-md-11">
 
 
-              <% if comment.sensitivity == "secreto" %>
+              <% if comment.sensitivity == "Secret" %>
                   <div class="bs-callout bs-callout-info-d" >
               <% else %>
-                  <% if comment.sensitivity == "privado" %>
+                  <% if comment.sensitivity == "Private" %>
                      <div class="bs-callout bs-callout-info-w" >
                   <% else %>
                      <div class="bs-callout bs-callout-info-s" >
@@ -136,10 +146,10 @@
                   <div class="row">
 
                       <!-- Creation time with symbol code for "Local/National/International" -->
-                      <% if comment.level == "international" %>
+                      <% if comment.level == "International" %>
                           <div class="col-md-3"> <small>(<%= comment.created_at %>)  &nbsp  </small> <span class="glyphicon glyphicon-globe"></span>  </div>
                       <% else %>
-                         <% if comment.level == "national" %>
+                         <% if comment.level == "National" %>
                             <div class="col-md-3">  <small>(<%= comment.created_at %>) &nbsp </small> <span class="glyphicon glyphicon-share-alt"></span>  </div>
                          <% else %>
                             <div class="col-md-3">  <small>(<%= comment.created_at %>) &nbsp </small> <span class="glyphicon glyphicon-chevron-right"></span> </div>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -1,7 +1,7 @@
 <div class="container">
   <div class="row">
     <h3>Users</h3>
-    <div class="column">
+    <!-- <div class="column"> -->
       <table class="table">
         <tbody>
           <% @users.each do |user| %>
@@ -11,6 +11,6 @@
           <% end %>
         </tbody>
       </table>
-    </div>
+    <!-- </div> -->
   </div>
 </div>

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -64,10 +64,21 @@ adilson = User.find_or_create_by!(email: 'adilson@example.com') do |user|
   user.confirm!
 end
 
+ladmin = User.find_or_create_by!(email: 'ladmin@example.com') do |user|
+  user.name = "Local Admin"
+  user.organization = comar
+  user.clearance = :Secret
+  user.role = :p4
+  user.password = 'change'
+  user.password_confirmation = 'change'
+  user.confirm!
+end
+
+
 # Criar situacoes de exemplo
-primeira = Situation.create(:user => adilson, :organization => adilson.organization, :name => "Homem ao mar", :description => "Este e um evento nacional que esta relacionado com a potencial existencia de um naufrago que caiu ao mar no brazil", :level => :local, :sensitivity => :Public)
-segunda = Situation.create(:user => diogo, :organization => diogo.organization, :name => "Poluicao no guincho", :description => "Este que esta relacionado com a potencial existencia de poluiacao no Guincho. Coitadinhas das focas.", :level => :national, :sensitivity => :Public)
-terceira = Situation.create(:user => diogo, :organization => diogo.organization, :name => "Homicidio no guincho", :description => "Este e um evento Internacional que esta relacionado com um potencial homicidio no guincho", :level => :national, :sensitivity => :Private)
+primeira = Situation.create(:user => adilson, :organization => adilson.organization, :name => "Homem ao mar", :description => "Este e um evento nacional que esta relacionado com a potencial existencia de um naufrago que caiu ao mar no brazil", :level => :Local, :sensitivity => :Public)
+segunda = Situation.create(:user => diogo, :organization => diogo.organization, :name => "Poluicao no guincho", :description => "Este que esta relacionado com a potencial existencia de poluiacao no Guincho. Coitadinhas das focas.", :level => :National, :sensitivity => :Public)
+terceira = Situation.create(:user => diogo, :organization => diogo.organization, :name => "Homicidio no guincho", :description => "Este e um evento Internacional que esta relacionado com um potencial homicidio no guincho", :level => :National, :sensitivity => :Private)
 quarta = Situation.create(:user => diogo, :organization => diogo.organization, :name => "Terrorismo no guincho", :level => :International, :sensitivity => :Secret)
 quinta = Situation.create(:user => diogo, :organization => diogo.organization, :name => "Navio Empanado", :level => :International, :sensitivity => :Private)
 sexta = Situation.create(:user => diogo, :organization => diogo.organization, :name => "Navio Afundado", :level => :National, :sensitivity => :Secret)

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -19,7 +19,7 @@ orgadmin = Organization.create(:name => "ADMIN", :country => "Portugal")
 user = CreateAdminService.new.call
   user.name = "Admin"
   user.organization = orgadmin
-  user.clearance = :secreto
+  user.clearance = :Secret
   user.role = :admin
   user.save!
 
@@ -29,7 +29,7 @@ user = CreateAdminService.new.call
 diogo = User.find_or_create_by!(email: 'diogo@example.com') do |user|
   user.name = "Diogo Monica"
   user.organization = comar
-  user.clearance = :secreto
+  user.clearance = :Secret
   user.role = :p3
   user.password = 'change'
   user.password_confirmation = 'change'
@@ -39,7 +39,7 @@ end
 nuno = User.find_or_create_by!(email: 'nuno@example.com') do |user|
   user.name = "Nuno Monica"
   user.organization = mrcc
-  user.clearance = :privado
+  user.clearance = :Private
   user.role = :p2
   user.password = 'change'
   user.password_confirmation = 'change'
@@ -57,7 +57,7 @@ end
 adilson = User.find_or_create_by!(email: 'adilson@example.com') do |user|
   user.name = "Adilson Fagundes"
   user.organization = inem
-  user.clearance = :secreto
+  user.clearance = :Secret
   user.role = :p3
   user.password = 'change'
   user.password_confirmation = 'change'
@@ -65,13 +65,13 @@ adilson = User.find_or_create_by!(email: 'adilson@example.com') do |user|
 end
 
 # Criar situacoes de exemplo
-primeira = Situation.create(:user => adilson, :organization => adilson.organization, :name => "Homem ao mar", :description => "Este e um evento nacional que esta relacionado com a potencial existencia de um naufrago que caiu ao mar no brazil", :level => :local, :sensitivity => :publico)
-segunda = Situation.create(:user => diogo, :organization => diogo.organization, :name => "Poluicao no guincho", :description => "Este que esta relacionado com a potencial existencia de poluiacao no Guincho. Coitadinhas das focas.", :level => :national, :sensitivity => :publico)
-terceira = Situation.create(:user => diogo, :organization => diogo.organization, :name => "Homicidio no guincho", :description => "Este e um evento Internacional que esta relacionado com um potencial homicidio no guincho", :level => :national, :sensitivity => :privado)
-quarta = Situation.create(:user => diogo, :organization => diogo.organization, :name => "Terrorismo no guincho", :level => :international, :sensitivity => :secreto)
-quinta = Situation.create(:user => diogo, :organization => diogo.organization, :name => "Navio Empanado", :level => :international, :sensitivity => :privado)
-sexta = Situation.create(:user => diogo, :organization => diogo.organization, :name => "Navio Afundado", :level => :national, :sensitivity => :secreto)
-setima = Situation.create(:user => diogo, :organization => diogo.organization, :name => "Apanha de ostras", :level => :local, :sensitivity => :privado)
+primeira = Situation.create(:user => adilson, :organization => adilson.organization, :name => "Homem ao mar", :description => "Este e um evento nacional que esta relacionado com a potencial existencia de um naufrago que caiu ao mar no brazil", :level => :local, :sensitivity => :Public)
+segunda = Situation.create(:user => diogo, :organization => diogo.organization, :name => "Poluicao no guincho", :description => "Este que esta relacionado com a potencial existencia de poluiacao no Guincho. Coitadinhas das focas.", :level => :national, :sensitivity => :Public)
+terceira = Situation.create(:user => diogo, :organization => diogo.organization, :name => "Homicidio no guincho", :description => "Este e um evento Internacional que esta relacionado com um potencial homicidio no guincho", :level => :national, :sensitivity => :Private)
+quarta = Situation.create(:user => diogo, :organization => diogo.organization, :name => "Terrorismo no guincho", :level => :International, :sensitivity => :Secret)
+quinta = Situation.create(:user => diogo, :organization => diogo.organization, :name => "Navio Empanado", :level => :International, :sensitivity => :Private)
+sexta = Situation.create(:user => diogo, :organization => diogo.organization, :name => "Navio Afundado", :level => :National, :sensitivity => :Secret)
+setima = Situation.create(:user => diogo, :organization => diogo.organization, :name => "Apanha de ostras", :level => :Local, :sensitivity => :Private)
 
 # Criar participacoes de exemplo
 primeira.organizations << [inem]
@@ -84,25 +84,25 @@ setima.organizations << [mrcc, comar]
 
 
 # Criar events
-evento1 = Event.create(:user => diogo, :organization => diogo.organization, situation: primeira, sensitivity: :publico, level: :local, title: "O homem caiu ao mar na figueira da foz")
-evento2 = Event.create(:user => diogo, :organization => diogo.organization, situation: primeira, sensitivity: :secreto, level: :local, title: "O morto foi identificado")
+evento1 = Event.create(:user => diogo, :organization => diogo.organization, situation: primeira, sensitivity: :Public, level: :Local, title: "O homem caiu ao mar na figueira da foz")
+evento2 = Event.create(:user => diogo, :organization => diogo.organization, situation: primeira, sensitivity: :Secret, level: :Local, title: "O morto foi identificado")
 
-evento3 = Event.create(:user => diogo, :organization => diogo.organization, situation: terceira, sensitivity: :publico, level: :international, decision: true, title: "Homem matou outro na praca")
-evento4 = Event.create(:user => diogo, :organization => diogo.organization, situation: terceira, sensitivity: :privado, level: :national, title: "Encontrada a arma do crime")
+evento3 = Event.create(:user => diogo, :organization => diogo.organization, situation: terceira, sensitivity: :Public, level: :International, decision: true, title: "Homem matou outro na praca")
+evento4 = Event.create(:user => diogo, :organization => diogo.organization, situation: terceira, sensitivity: :Private, level: :National, title: "Encontrada a arma do crime")
 
-evento5 = Event.create(:user => diogo, :organization => diogo.organization, situation: quarta, sensitivity: :secreto, level: :local, title: "Foi encontrada uma bomba na praca. A razao pela qual ela não rebentou não é, de momento, conhecida. Há quem diga que não recentou porque, sendo uma bomba de ar manual, daquelas de dar ao pedal, e não estando lá niguém a pedalar, dificilmente aquilo poderia ter criado pressão para rebentar. Mas o facto é, que, honestamente, não sabemos")
+evento5 = Event.create(:user => diogo, :organization => diogo.organization, situation: quarta, sensitivity: :Secret, level: :Local, title: "Foi encontrada uma bomba na praca. A razao pela qual ela não rebentou não é, de momento, conhecida. Há quem diga que não recentou porque, sendo uma bomba de ar manual, daquelas de dar ao pedal, e não estando lá niguém a pedalar, dificilmente aquilo poderia ter criado pressão para rebentar. Mas o facto é, que, honestamente, não sabemos")
 
 # Criar comments
 
-c = Comment.create(:body => "O homem tinha uma tshirt vermelha", :event => evento1, :user => diogo, :organization => diogo.organization, sensitivity: :publico, level: :local)
-c = Comment.create(:body => "O homem tinha uma mulher feiosa", :event => evento1, :user => diogo, :organization => diogo.organization, :sensitivity => :secreto, level: :local)
+c = Comment.create(:body => "O homem tinha uma tshirt vermelha", :event => evento1, :user => diogo, :organization => diogo.organization, sensitivity: :Public, level: :Local)
+c = Comment.create(:body => "O homem tinha uma mulher feiosa", :event => evento1, :user => diogo, :organization => diogo.organization, :sensitivity => :Secret, level: :Local)
 
 c = Comment.create(:body => "O homem matou o outro com uma faca, embora ninguém a tenha visto. Aliás, há bastantes dúvidas de que a faca fosse mesmo uma faca, e não apenas um 
                             corta-unhas que o criminoso tinha. É certo que, sendo o homicida um gajo com umas u
-                            nhas enormes, o corta-unhas não podia ser pequeno. Mas crime é crime, bolas.", :event => evento3, :user => diogo, :organization => diogo.organization, sensitivity: :publico, level: :local)
-c = Comment.create(:body => "A faca tinha 30 Cms", :event => evento4, :user => diogo, :organization => diogo.organization, sensitivity: :privado, level: :national)
-c = Comment.create(:body => "A faca tinha um cabo metalico", :event => evento4, :user => diogo, :organization => diogo.organization, sensitivity: :publico, level: :national)
-c = Comment.create(:body => "A faca tinha era afiada", :event => evento4, :user => diogo, :organization => diogo.organization, sensitivity: :publico, level: :local)
+                            nhas enormes, o corta-unhas não podia ser pequeno. Mas crime é crime, bolas.", :event => evento3, :user => diogo, :organization => diogo.organization, sensitivity: :Public, level: :Local)
+c = Comment.create(:body => "A faca tinha 30 Cms", :event => evento4, :user => diogo, :organization => diogo.organization, sensitivity: :Private, level: :National)
+c = Comment.create(:body => "A faca tinha um cabo metalico", :event => evento4, :user => diogo, :organization => diogo.organization, sensitivity: :Public, level: :National)
+c = Comment.create(:body => "A faca tinha era afiada", :event => evento4, :user => diogo, :organization => diogo.organization, sensitivity: :Public, level: :Local)
 
 
-c = Comment.create(:body => "A bomba era amarela", :event => evento5, :user => diogo, :organization => diogo.organization, sensitivity: :publico, level: :international)
+c = Comment.create(:body => "A bomba era amarela", :event => evento5, :user => diogo, :organization => diogo.organization, sensitivity: :Public, level: :International)

--- a/spec/factories/comments.rb
+++ b/spec/factories/comments.rb
@@ -4,8 +4,8 @@ FactoryGirl.define do
     association :user, factory: :user
 
     body 'This is a cool comment!'
-    level :local
-    sensitivity :secreto
+    level :Local
+    sensitivity :Secret
  end
 
   trait :with_comments do

--- a/spec/factories/events.rb
+++ b/spec/factories/events.rb
@@ -5,6 +5,6 @@ FactoryGirl.define do
 
     sequence(:title) { |n| "This is a new event with ID: #{n}" }
     level :local
-    sensitivity :secreto
+    sensitivity :Secret
   end
 end

--- a/spec/factories/events.rb
+++ b/spec/factories/events.rb
@@ -4,7 +4,7 @@ FactoryGirl.define do
     association :user, factory: :user
 
     sequence(:title) { |n| "This is a new event with ID: #{n}" }
-    level :local
+    level :Local
     sensitivity :Secret
   end
 end

--- a/spec/factories/situations.rb
+++ b/spec/factories/situations.rb
@@ -4,7 +4,7 @@ FactoryGirl.define do
     association :organization, factory: :organization
 
     sequence(:name) { |n| "This is a new situation with ID: #{n}" }
-    level :local
-    sensitivity :secreto
+    level :Local
+    sensitivity :Secret
   end
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -6,7 +6,7 @@ FactoryGirl.define do
     sequence(:email) { |n| "test#{n}@example.com" }
     password "please123"
     role :p1
-    clearance :publico
+    clearance :Public
 
     trait :admin do
       role 'admin'

--- a/spec/features/situations/situation_show_spec.rb
+++ b/spec/features/situations/situation_show_spec.rb
@@ -5,7 +5,7 @@ feature 'User views situation' do
   let!(:user) { situation.user }
 
   before(:each) do
-    user.update_attributes(organization: situation.organization, role: :p3, clearance: :secreto)
+    user.update_attributes(organization: situation.organization, role: :p3, clearance: :Secret)
     situation.update_attributes(organizations: [situation.organization])
     signin(user.email, user.password)
   end

--- a/spec/policies/situation_policy_spec.rb
+++ b/spec/policies/situation_policy_spec.rb
@@ -25,36 +25,36 @@ describe SituationPolicy do
     end
 
     it "lists situations with equal sensitivity than current user's clearance" do
-      situation.update_attributes(sensitivity: :publico)
+      situation.update_attributes(sensitivity: :Public)
       expect(policy_scope).to eq [situation]
       expect(subject).to permit(user, situation)
     end
 
     it "lists situations with lower sensitivity than current user's clearance" do
-      situation.update_attributes(sensitivity: :privado)
-      user.update_attributes(clearance: :secreto)
+      situation.update_attributes(sensitivity: :Private)
+      user.update_attributes(clearance: :Secret)
       expect(policy_scope).to eq [situation]
       expect(subject).to permit(user, situation)
     end
 
     it "when admin it list situations when organization doesn't participate in them" do
-      situation.update_attributes(sensitivity: :publico, organizations: [])
-      user.update_attributes(clearance: :secreto)
+      situation.update_attributes(sensitivity: :Public, organizations: [])
+      user.update_attributes(clearance: :Secret)
       user.update_attributes(role: :admin)
       expect(policy_scope).to eq [situation]
       expect(subject).to permit(user, situation)
     end
 
       it "does not list situations when organization doesn't participate in them" do
-      situation.update_attributes(sensitivity: :publico, organizations: [])
-      user.update_attributes(clearance: :secreto)
+      situation.update_attributes(sensitivity: :Public, organizations: [])
+      user.update_attributes(clearance: :Secret)
       expect(policy_scope).to eq []
       expect(subject).not_to permit(user, situation)
     end
 
     it "lists situations when level is national and organization is in the same country" do
       new_org = FactoryGirl.create(:organization, country: situation.organization.country)
-      situation.update_attributes(level: :national, sensitivity: :publico, organization: new_org,
+      situation.update_attributes(level: :National, sensitivity: :Public, organization: new_org,
         organizations: [new_org, user.organization])
       expect(policy_scope).to eq [situation]
       expect(subject).to permit(user, situation)
@@ -62,54 +62,54 @@ describe SituationPolicy do
 
     it "does not list situations when level is national and organization is different country" do
       new_org = FactoryGirl.create(:organization, country: 'Other Country')
-      situation.update_attributes(level: :national, sensitivity: :publico, organization: new_org,
+      situation.update_attributes(level: :National, sensitivity: :Public, organization: new_org,
         organizations: [new_org, user.organization])
       expect(policy_scope).to eq []
       expect(subject).not_to permit(user, situation)
     end
 
     it "lists situations when level is local and organization is owner" do
-      situation.update_attributes(level: :local, sensitivity: :publico)
+      situation.update_attributes(level: :Local, sensitivity: :Public)
       expect(policy_scope).to eq [situation]
       expect(subject).to permit(user, situation)
     end
 
     it "does not list situations when level is local and organization is not the owner" do
       new_org = FactoryGirl.create(:organization, country: situation.organization.country)
-      situation.update_attributes(level: :local, sensitivity: :publico, organization: new_org,
+      situation.update_attributes(level: :Local, sensitivity: :Public, organization: new_org,
         organizations: [new_org, user.organization])
       expect(policy_scope).to eq []
       expect(subject).not_to permit(user, situation)
     end
 
     it "lists situations when level international" do
-      situation.update_attributes(level: :international, sensitivity: :publico)
+      situation.update_attributes(level: :International, sensitivity: :Public)
       expect(policy_scope).to eq [situation]
       expect(subject).to permit(user, situation)
     end
 
     it "does not list situations when level international but sensitivity is secret" do
-      situation.update_attributes(level: :international, sensitivity: :secreto)
+      situation.update_attributes(level: :International, sensitivity: :Secret)
       expect(policy_scope).to eq []
       expect(subject).not_to permit(user, situation)
     end
 
     it "does not list situations when active is false" do
-      situation.update_attributes(active: false, sensitivity: :publico)
+      situation.update_attributes(active: false, sensitivity: :Public)
       expect(policy_scope).to eq []
       expect(subject).not_to permit(user, situation)
     end
 
     it "when admin it lists situations when active is false" do
-      situation.update_attributes(active: false, sensitivity: :publico)
+      situation.update_attributes(active: false, sensitivity: :Public)
       user.update_attributes(role: :admin)
       expect(policy_scope).to eq [situation]
       expect(subject).to permit(user, situation)
     end
 
     it "allows user with private to access public situation" do
-      situation.update_attributes(sensitivity: :publico)
-      user.update_attributes(clearance: :privado)
+      situation.update_attributes(sensitivity: :Public)
+      user.update_attributes(clearance: :Private)
 
       expect(policy_scope).to eq [situation]
       expect(subject).to permit(user, situation)
@@ -139,7 +139,7 @@ describe SituationPolicy do
     end
 
     it "updates a new situation when user is p3 and owner" do
-      situation.update_attributes(sensitivity: :publico)
+      situation.update_attributes(sensitivity: :Public)
       user.update_attributes(role: :p3)
       expect(subject).to permit(user, situation)
     end


### PR DESCRIPTION
User profiles P0 and P4 created. 
- A P0 is a user who signed up and used the confirmation link and, thus, belongs to the system (but has not been validated by nobody). Hence, he sees nothing until someone promotes him to at least P1.
- A P4 is a local administrator, in the sense that, in addition to the P3 capabilities, he can: 1. Promote users within his own organization; 2. Create a new organization.

Some functional bugs corrected: 
- On the sign-up form, the organization name has noe the country appended, to avoid ambiguity
- On the sign-up form, the phantom ADMIN organization (to which the Admin belongs) is now filtered out.